### PR TITLE
Exclude "ghost" nodes of live copies from the dialog

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
+++ b/src/main/resources/SLING-INF/apps/namics/genericmultifield/clientlibs/js/CUI.GenericMultiField.js
@@ -80,7 +80,8 @@
             }).done(function (data) {
                 that.ol.empty();
                 $.each(data, function (key) {
-                    if (typeof data[key] === 'object' && !Array.isArray(data[key]) && data[key] !== undefined && data[key]["jcr:primaryType"] !== undefined) {
+                    if (typeof data[key] === 'object' && !Array.isArray(data[key]) && data[key] !== undefined && data[key]["jcr:primaryType"] !== undefined
+                        && data[key]["sling:resourceType"] !== "wcm/msm/components/ghost") {
 
                         if (that.itemNameDisplayStrategy === "pageTitle") {
                             //use the jcr:title from a page


### PR DESCRIPTION
When a node is removed for a live copy it is not actually removed from JCR. It removes all the properties for this node and sets "sling:resourceType" property for it equal to "wcm/msm/components/ghost":

![image](https://user-images.githubusercontent.com/3950000/224681348-9f983f60-11b3-4789-97dd-78ad4cbab6c5.png)

>>MSM ghost node is needed in author for re-enabling inheritance in future. 
https://experienceleaguecommunities.adobe.com/t5/adobe-experience-manager/issue-with-wcm-msm-components-ghost/m-p/371261

The Generic Multifield widget shows those "ghost" nodes but they cannot be removed:

![image](https://user-images.githubusercontent.com/3950000/224681955-9b053a80-f25b-4928-ba60-d7b731375339.png)

The solution is to exclude the nodes and not show them in the widget.