### PR TITLE
Add copy functionality to GenericMultiField

### DIFF
--- a/src/main/resources/SLING-INF/apps/merkle/genericmultifield/clientlibs/css/genericmultifield.css
+++ b/src/main/resources/SLING-INF/apps/merkle/genericmultifield/clientlibs/css/genericmultifield.css
@@ -28,7 +28,8 @@
 
 .coral-SpectrumMultiField-edit,
 .coral-SpectrumMultiField-remove,
-.coral-SpectrumMultiField-move {
+.coral-SpectrumMultiField-move,
+.coral-SpectrumMultiField-copy {
     width: 41px;
     height: 41px;
 }
@@ -63,6 +64,12 @@
     position: absolute;
     top: 0;
     right: 0;
+}
+
+.coral-SpectrumMultiField-copy {
+    position: absolute;
+    top: 0;
+    right: 6.3rem;
 }
 
 .coral-GenericMultiField .coral-GenericMultiField-listEntry {


### PR DESCRIPTION
- Introduced a new copy button in the GenericMultiField interface.
- Implemented the _copyItem method to handle item duplication.
- Added CSS styles for the copy button.
- Updated the crxPath retrieval logic to support data-formid attribute.
- Ensured copy button is disabled in read-only mode.

<img width="1156" height="144" alt="Screenshot 2025-08-12 at 12 08 54" src="https://github.com/user-attachments/assets/cb3e457b-67db-44f0-bd80-f8731f7755a3" />
<img width="1164" height="197" alt="Screenshot 2025-08-12 at 12 09 06" src="https://github.com/user-attachments/assets/1de8728e-2939-49a3-b191-abc10542d35b" />
<img width="1168" height="193" alt="Screenshot 2025-08-12 at 12 09 12" src="https://github.com/user-attachments/assets/72542813-6b81-4194-93da-fc0fa1fe98b4" />
